### PR TITLE
Fixes to compile under OSX 10.9

### DIFF
--- a/Calibrator.cpp
+++ b/Calibrator.cpp
@@ -14,7 +14,7 @@ FrameFunction::~FrameFunction() {
 
 MovingTarget::MovingTarget(const int &frameno, 
 			   const vector<Point>& points, 
-			   const shared_ptr<WindowPointer> &pointer,
+               const boost::shared_ptr<WindowPointer> &pointer,
 			   int dwelltime):
     FrameFunction(frameno), 
     points(points), dwelltime(dwelltime), pointer(pointer)
@@ -70,9 +70,9 @@ Point MovingTarget::getActivePoint() {
 }
 
 Calibrator::Calibrator(const int &framecount, 
-               const shared_ptr<TrackingSystem> &trackingsystem,
+               const boost::shared_ptr<TrackingSystem> &trackingsystem,
                const vector<Point>& points, 
-               const shared_ptr<WindowPointer> &pointer,
+               const boost::shared_ptr<WindowPointer> &pointer,
                int dwelltime): 
     MovingTarget(framecount, points, pointer, dwelltime),
     trackingsystem(trackingsystem)

--- a/Calibrator.h
+++ b/Calibrator.h
@@ -26,11 +26,11 @@ class FrameProcessing:
 public ProcessContainer<FrameProcessing,FrameFunction> {};
 
 class MovingTarget: public FrameFunction {
-    shared_ptr<WindowPointer> pointer;
+    boost::shared_ptr<WindowPointer> pointer;
  public:
     MovingTarget(const int &frameno, 
 		 const vector<Point>& points, 
-		 const shared_ptr<WindowPointer> &pointer,
+		 const boost::shared_ptr<WindowPointer> &pointer,
 		 int dwelltime=20);
     virtual ~MovingTarget();
     virtual void process();
@@ -47,16 +47,16 @@ class MovingTarget: public FrameFunction {
 
 class Calibrator: public MovingTarget {
     static const Point defaultpointarr[];
-    shared_ptr<TrackingSystem> trackingsystem;
+    boost::shared_ptr<TrackingSystem> trackingsystem;
     scoped_ptr<FeatureDetector> averageeye;
     scoped_ptr<FeatureDetector> averageeye_left;
 public:
     static vector<Point> defaultpoints;
     static vector<Point> loadpoints(istream& in);
     Calibrator(const int &frameno, 
-	       const shared_ptr<TrackingSystem> &trackingsystem, 
+	       const boost::shared_ptr<TrackingSystem> &trackingsystem, 
 	       const vector<Point>& points, 
-	       const shared_ptr<WindowPointer> &pointer,
+	       const boost::shared_ptr<WindowPointer> &pointer,
 	       int dwelltime=20);
     virtual ~Calibrator();
     virtual void process();

--- a/Containers.h
+++ b/Containers.h
@@ -22,7 +22,7 @@ class  Containee {
 
 template <class ParentType, class ChildType>		
 class BaseContainer {
-    typedef shared_ptr<ChildType> ChildPtr;
+    typedef boost::shared_ptr<ChildType> ChildPtr;
     static bool isFinished(const ChildPtr &object) { 
 	return !(object && object->parent);
     }

--- a/FMatrixAffineCompute.cpp
+++ b/FMatrixAffineCompute.cpp
@@ -1,4 +1,5 @@
 #include <vnl/algo/vnl_svd.h>
+#include"PointTracker.h"
 
 template <class T>
 

--- a/FeatureDetector.cpp
+++ b/FeatureDetector.cpp
@@ -18,14 +18,14 @@ void FeatureDetector::addSample(const IplImage *source) {
     samples++;
 }
 
-shared_ptr<IplImage> FeatureDetector::getMean() {
-    shared_ptr<IplImage> mean(createImage(eyesize, IPL_DEPTH_32F, 1));
+boost::shared_ptr<IplImage> FeatureDetector::getMean() {
+    boost::shared_ptr<IplImage> mean(createImage(eyesize, IPL_DEPTH_32F, 1));
     cvConvertScale(sumimage.get(), mean.get(), 1.0 / samples);
     return mean;
 }
 
-shared_ptr<IplImage> FeatureDetector::getVariance() {
-    shared_ptr<IplImage> variance(createImage(eyesize, IPL_DEPTH_32F, 1));
+boost::shared_ptr<IplImage> FeatureDetector::getVariance() {
+    boost::shared_ptr<IplImage> variance(createImage(eyesize, IPL_DEPTH_32F, 1));
     cvMul(sumimage.get(), sumimage.get(), temp.get(), -1.0/samples);
     cvAdd(temp.get(), sum2image.get(), temp.get());
     cvScale(temp.get(), variance.get(), 1.0/samples);

--- a/FeatureDetector.h
+++ b/FeatureDetector.h
@@ -8,6 +8,6 @@ class FeatureDetector {
 public:
     FeatureDetector(CvSize eyesize);
     void addSample(const IplImage *source);
-    shared_ptr<IplImage> getMean();
-    shared_ptr<IplImage> getVariance();
+    boost::shared_ptr<IplImage> getMean();
+    boost::shared_ptr<IplImage> getVariance();
 };

--- a/GaussianProcess.cpp
+++ b/GaussianProcess.cpp
@@ -1,4 +1,5 @@
 #include <vnl/algo/vnl_cholesky.h>
+#include "utils.h"
 
 class MultiGaussian {
 public:

--- a/GazeArea.cpp
+++ b/GazeArea.cpp
@@ -3,7 +3,7 @@
 #include <opencv/cv.h>
 
 GazeArea::GazeArea(int argc, char **argv, 
-		   const vector<shared_ptr<AbstractStore> > &stores):
+           const vector<boost::shared_ptr<AbstractStore> > &stores):
     lastPointId(-1), gazetracker(argc, argv, stores)
 {
     set_size_request(gazetracker.canvas->width, gazetracker.canvas->height);

--- a/GazeArea.h
+++ b/GazeArea.h
@@ -10,7 +10,7 @@ class GazeArea: public Gtk::DrawingArea {
     MainGazeTracker gazetracker;
 
     GazeArea(int argc, char **argv,
-	     const vector<shared_ptr<AbstractStore> > &stores);
+         const vector<boost::shared_ptr<AbstractStore> > &stores);
     virtual ~GazeArea();
 
  protected:

--- a/GazeTrackerGtk.cpp
+++ b/GazeTrackerGtk.cpp
@@ -3,12 +3,12 @@
 #include <iostream>
 #include "GtkStore.h"
 
-static vector<shared_ptr<AbstractStore> > getStores() {
-    vector<shared_ptr<AbstractStore> > stores;
+static vector<boost::shared_ptr<AbstractStore> > getStores() {
+    vector<boost::shared_ptr<AbstractStore> > stores;
 
-    stores.push_back(shared_ptr<AbstractStore>(new SocketStore()));
-    stores.push_back(shared_ptr<AbstractStore>(new StreamStore(cout)));
-    stores.push_back(shared_ptr<AbstractStore>
+    stores.push_back(boost::shared_ptr<AbstractStore>(new SocketStore()));
+    stores.push_back(boost::shared_ptr<AbstractStore>(new StreamStore(cout)));
+    stores.push_back(boost::shared_ptr<AbstractStore>
       (new WindowStore(WindowPointer::PointerSpec(20, 30, 0, 0, 1),
 			   WindowPointer::PointerSpec(20, 20, 0, 1, 1),
 		       WindowPointer::PointerSpec(30, 30, 1, 0, 1))));

--- a/GraphicalPointer.h
+++ b/GraphicalPointer.h
@@ -5,7 +5,7 @@
 /* represents the pointer as a small window and moves that window */
 class WindowPointer {
  public:
-	shared_ptr<WindowPointer> mirror;
+    boost::shared_ptr<WindowPointer> mirror;
     struct PointerSpec {
 	int width, height;
 	double red, green, blue;

--- a/HeadCompensation.cpp
+++ b/HeadCompensation.cpp
@@ -1,4 +1,5 @@
 #include "LeastSquares.h"
+#include "HeadTracker.h"
 
 class HeadCompensation {
     LeastSquares xparams, yparams;

--- a/MainGazeTracker.cpp
+++ b/MainGazeTracker.cpp
@@ -194,7 +194,7 @@ VideoInput::~VideoInput() {
 }
 
 MainGazeTracker::MainGazeTracker(int argc, char** argv, 
-				 const vector<shared_ptr<AbstractStore> > 
+                 const vector<boost::shared_ptr<AbstractStore> >
 				 &stores): 
     framestoreload(-1), stores(stores), autoreload(false), videooverlays(false), totalframecount(0), recording(false), commandindex(-1)
 //     , statemachine(shared_ptr<AlertWindow>(new AlertWindow("start")))
@@ -808,13 +808,13 @@ void MainGazeTracker::startCalibration() {
 		*commandoutputfile << totalframecount << " CALIBRATE" << endl;
 	}
 	
-    shared_ptr<WindowPointer> 
+    boost::shared_ptr<WindowPointer> 
 	pointer(new WindowPointer(WindowPointer::PointerSpec(30,30,1,0,0.2)));
 	
 	game_win->setCalibrationPointer(pointer.get());
 	
 	if(Gdk::Screen::get_default()->get_n_monitors() > 1) {
-	    shared_ptr<WindowPointer> 
+	    boost::shared_ptr<WindowPointer> 
 		mirror(new WindowPointer(WindowPointer::PointerSpec(30,30,1,0,0)));
 	
 		pointer->mirror = mirror;
@@ -822,7 +822,7 @@ void MainGazeTracker::startCalibration() {
 
     ifstream calfile((directory + "/calpoints.txt").c_str());
 
-    shared_ptr<Calibrator> 
+    boost::shared_ptr<Calibrator> 
 	cal(new Calibrator(framecount, tracking, 
 				  scalebyscreen(Calibrator::loadpoints(calfile)),
 				  pointer, dwelltime_parameter));
@@ -845,13 +845,13 @@ void MainGazeTracker::startTesting() {
 	
     vector<Point> points;
 
-    shared_ptr<WindowPointer> 
+    boost::shared_ptr<WindowPointer> 
 	pointer(new WindowPointer(WindowPointer::PointerSpec(30,30,1,0,0.2)));
 	
 	game_win->setCalibrationPointer(pointer.get());
 	
 	if(Gdk::Screen::get_default()->get_n_monitors() > 1) {
-		shared_ptr<WindowPointer> 
+        boost::shared_ptr<WindowPointer>
 		mirror(new WindowPointer(WindowPointer::PointerSpec(30,30,1,0,0)));
 	
 		pointer->mirror = mirror;
@@ -861,7 +861,7 @@ void MainGazeTracker::startTesting() {
     ifstream calfile((directory + "/testpoints.txt").c_str());
 	points = Calibrator::loadpoints(calfile);
 	
-	shared_ptr<MovingTarget> 
+    boost::shared_ptr<MovingTarget>
 	moving(new MovingTarget(framecount, scalebyscreen(points), pointer, test_dwelltime_parameter));
 	
 	target = moving.operator->();

--- a/MainGazeTracker.h
+++ b/MainGazeTracker.h
@@ -61,7 +61,7 @@ class VideoWriter;
 class MainGazeTracker {
     scoped_ptr<VideoWriter> video;
     int framestoreload;
-    vector<shared_ptr<AbstractStore> > stores;
+    vector<boost::shared_ptr<AbstractStore> > stores;
     int framecount;
     bool autoreload;
 	string directory;
@@ -88,7 +88,7 @@ class MainGazeTracker {
  public:	
 	//bool isTesting;
 	bool isCalibrationOutputWritten;
-    shared_ptr<TrackingSystem> tracking;
+    boost::shared_ptr<TrackingSystem> tracking;
 	MovingTarget* target;
 
     FrameProcessing framefunctions;
@@ -97,7 +97,7 @@ class MainGazeTracker {
 	
 
     MainGazeTracker(int argc, char** argv,
-		    const vector<shared_ptr<AbstractStore> > &stores);
+            const vector<boost::shared_ptr<AbstractStore> > &stores);
     void doprocessing(void);
 	void simulateClicks(void);
     ~MainGazeTracker(void);

--- a/utils.cpp
+++ b/utils.cpp
@@ -12,8 +12,8 @@ void releaseImage(IplImage *image) {
     cvReleaseImage(&image);
 }
 
-shared_ptr<IplImage> createImage(const CvSize &size, int depth, int channels) {
-    return shared_ptr<IplImage>(cvCreateImage(size, depth, channels),
+boost::shared_ptr<IplImage> createImage(const CvSize &size, int depth, int channels) {
+    return boost::shared_ptr<IplImage>(cvCreateImage(size, depth, channels),
 				releaseImage);
 }
 

--- a/utils.h
+++ b/utils.h
@@ -189,14 +189,14 @@ namespace boost {
 }
 
 void releaseImage(IplImage *image);
-shared_ptr<IplImage> createImage(const CvSize &size, int depth, int channels);
+boost::shared_ptr<IplImage> createImage(const CvSize &size, int depth, int channels);
 void mapToFirstMonitorCoordinates(Point monitor2point, Point& monitor1point);
 void mapToVideoCoordinates(Point monitor2point, double resolution, Point& videoPoint, bool reverse_x = true);
 void mapToNeuralNetworkCoordinates(Point point, Point& nnpoint);
 void mapFromNeuralNetworkToScreenCoordinates(Point nnpoint, Point& point);
 string getUniqueFileName(string directory, string base_file_name);
 
-typedef shared_ptr<const IplImage> SharedImage;
+typedef boost::shared_ptr<const IplImage> SharedImage;
 
 void normalizeGrayScaleImage(IplImage *image, double standard_mean = 127, double standard_std = 50);
 void normalizeGrayScaleImage2(IplImage *image, double standard_mean = 127, double standard_std = 50);


### PR DESCRIPTION
Dear Onur,

Please find here some fixes to compile OpenGazer/CVC Eye-Tracker under OSX 10.9, mostly forcing the namespace of shared_ptr to boost and some missing includes. I also had to fix vxl too, a Portfile is available here https://github.com/ChristianFrisson/MacPortsCycles for that purpose.

Best regards,
Christian
